### PR TITLE
allowed null entries in the last parsed feed

### DIFF
--- a/feeds.yml
+++ b/feeds.yml
@@ -1,5 +1,5 @@
-# This is a template for adding feeds:
-sample_feed:  # Replace this label with the name of the feed.
-  # It's recommended that you populate this field with the link to the most recent entry from the feed. It will be updated automatically.
-  last_entry: https://frame.work/blog/introducing-the-framework-laptop-chromebook-edition
+# Comments in this file will be overwritten. 
+sample_feed:  # The name of the feed that will appear in the subject of emails.
+  last_entry: null  # This stores the last entry that was already parsed to prevent duplicate emails.
+                    # It will be populated on first run if you leave it as null.
   url: https://frame.work/blog.rss  # The URL to the feed itself.

--- a/src/rss-to-email/__main__.py
+++ b/src/rss-to-email/__main__.py
@@ -1,3 +1,4 @@
+import random
 import time
 
 import config
@@ -5,11 +6,24 @@ import email_api
 import rss
 
 
-while True:
-    # Get the list of new entries and send each of them as an email.
-    new_entries = rss.get_new_entries(config.load_feeds())
-    for entry in new_entries:
-        email_api.send_entry(entry)
+def main():
+    # Check if it's the first run of the config file.
+    feeds = config.load_feeds()
+    # Get the last entry field from a random feed.
+    last_entry = random.choice(list(feeds.values()))["last_entry"]
+    if not last_entry:
+        rss.get_new_entries(feeds, count=1)
 
-    # Wait 10m between polls
-    time.sleep(600)
+    # Start the poll loop.
+    while True:
+        # Get the list of new entries and send each of them as an email.
+        new_entries = rss.get_new_entries(config.load_feeds())
+        for entry in new_entries:
+            email_api.send_entry(entry)
+
+        # Wait 10m between polls
+        time.sleep(600)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rss-to-email/rss.py
+++ b/src/rss-to-email/rss.py
@@ -2,25 +2,34 @@ import config
 import feedparser
 
 
-def get_new_entries(feeds: dict) -> list:
+def get_new_entries(feeds: dict, count: int = 0) -> list:
     """Gets a list of entries added to each feed since the last time it was parsed.
 
     :param feeds: Dict of feed as loaded py `config.load_feeds()`
     :type feeds: dict
+    :param count: Optional - tells the parser how many entries to return from
+    the top of the list. If specified, the parser will ignore the last_entry field.
+    :type count: int
     :return: List of tuples for each new entry in the format (feed_name, entry)
     :rtype: list
     """
     new_entries = []
     for feed in feeds:
         parsed_feed = feedparser.parse(feeds[feed]["url"])
-        # Go through entries and process any that were published since the feed was last parsed.
-        for entry in parsed_feed.entries:
-            # If the entry is new, add it to the list to return.
-            if entry.link != feeds[feed]["last_entry"]:
-                new_entries.append((feed, entry))
-            # Break if the entry is not new.
-            else:
-                break
+        # If the count was specified, add the first x-number of entries to the list to return as tuples.
+        if count:
+            for i in range(0, count):
+                new_entries.append((feed, parsed_feed.entries[i]))
+
+        # If the count was not specified, return each new entry until the feed was last parsed.
+        else:
+            for entry in parsed_feed.entries:
+                # If the entry is new, add it to the list to return.
+                if entry.link != feeds[feed]["last_entry"]:
+                    new_entries.append((feed, entry))
+                # Break if the entry is not new.
+                else:
+                    break
 
         # Update the last entry to be the most recent item.
         feeds[feed]["last_entry"] = parsed_feed.entries[0].link


### PR DESCRIPTION
## Describe Your Changes:
Allowed null entries to be populated on first run for new feeds.

### Linked Issues:
Closes #6

## Change Type
### Category
- [ ] This is a Minor Change which does not fit any other category.
- [ ] This is a Bugfix
- [x] This is a Feature Addition
- [ ] This is a CI Change
- [ ] This is a Documentation-Only Change (do not check any of the above boxes if this box is checked)
### Breaking/Non Breaking
- [ ] This is a Breaking Change
- [x] This is a Non-Breaking Change

#### Reasoning
If you answered "This is a Breaking Change" above, explain why your
change cannot be implemented in a non-breaking way. If you answered "This is a Non-Breaking Change", you can delete this section.

## Copyright Assignment
- [ ] I have filled out the copyright assignment at https://copyright.morpheus636.com for this pull request.
- [x] I **am** Morpheus636 so I do not need to fill out the copyright assignment.

#### Why do I require a copyright assignment?
<details>
<summary> Click to expand </summary>
I require a copyright assignment for changes to my projects for the same reason as the Free Software Foundation, and they do a much better job of explaining it in their post at https://www.gnu.org/licenses/why-assign.en.html than I could ever do.


Please email any questions about the copyright assignment to COPYRIGHT@morpheus636.com
</details>
